### PR TITLE
add simple plain authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 # do not include gem to github
 midi-smtp-server-*.gem
+**.swp
+**.swo

--- a/examples/client.rb
+++ b/examples/client.rb
@@ -1,0 +1,16 @@
+msgstr = <<END_OF_MESSAGE
+From: Your Name <your@mail.address>
+To: Destination Address <someone@example.com>
+Subject: test message
+Date: Sat, 23 Jun 2001 16:26:43 +0900
+Message-Id: <unique.message.id.string@example.com>
+
+This is a test message.
+END_OF_MESSAGE
+
+require 'net/smtp'
+
+smtp = Net::SMTP.start('127.0.0.1', 2525, 'mail.address', 'testuser', 'testpass', :plain)
+# smtp = Net::SMTP.start('127.0.0.1', 2525, 'mail.address')
+smtp.send_message msgstr, 'your@mail.address', 'someone@example.com'
+smtp.finish

--- a/examples/midi-smtp-server-auth-example.rb
+++ b/examples/midi-smtp-server-auth-example.rb
@@ -1,0 +1,48 @@
+require "../lib/midi-smtp-server.rb"
+require "mail"
+require "byebug"
+
+IP_ADDR = "127.0.0.1"
+PORT = 2525
+MAX_CONNECTIONS = 4
+OPTS = {
+  :users_path => "./users"
+}
+
+class MySmtpd < MidiSmtpServer::Smtpd
+  def start
+    super
+  end
+
+  def on_message_data_event(ctx)
+    raise MidiSmtpServer::Smtpd535Exception if(ctx[:is_authenticated] == nil)
+    # Output for debug
+    logger.debug("[#{ctx[:envelope][:from]}] for recipient(s): [#{ctx[:envelope][:to]}]...")
+
+    # Just decode message ones to make sure, that this message ist readable
+    @mail = Mail.read_from_string(ctx[:message][:data])
+
+    # handle incoming mail, just show the message source
+    logger.debug(@mail.to_s)
+  end
+end
+
+puts "#{Time.now}: Starting MySmtpd..."
+
+server = MySmtpd.new(PORT, IP_ADDR, MAX_CONNECTIONS, OPTS)
+server.start
+sleep 1
+server.join
+
+BEGIN {
+  at_exit {
+    if server
+      puts "#{Time.now}: Shutdown MySmtpd..."
+      server.shutdown
+      sleep 2 unless server.connections == 0
+      server.stop
+    end
+
+    puts "#{Time.now}: MySmtpd down!"
+  }
+}

--- a/examples/users
+++ b/examples/users
@@ -1,0 +1,1 @@
+testuser testpass


### PR DESCRIPTION
Thank you for your gem.
I'm very happy to use that.

I just added a simple plain authentication.
You can see how to use by examples/midi-smtp-server-auth-example.rb.