### PR TITLE
Support cert chain in TLS

### DIFF
--- a/lib/midi-smtp-server/tls-transport.rb
+++ b/lib/midi-smtp-server/tls-transport.rb
@@ -44,14 +44,14 @@ module MidiSmtpServer
         raise "File \”#{@key_path}\" does not exist or is not a regular file. Could not load private key." unless File.file?(@key_path.to_s)
         # try to load certificate and key
         cert_lines = File.read(@cert_path.to_s).lines
-        cert_indexes = cert_lines.each_with_index.map{|line, index| index if line.match?(/BEGIN CERT/)}.compact
+        cert_indexes = cert_lines.each_with_index.map { |line, index| index if line.include?('BEGIN CERT') }.compact
         certs = []
         cert_indexes.each_with_index do |cert_index, current_index|
           end_index = (cert_indexes[current_index + 1] || 0) - 1
           certs << OpenSSL::X509::Certificate.new(cert_lines[cert_index..end_index].join)
         end
         @ssl_context.cert = certs[0]
-        @ssl_context.extra_chain_cert = certs[1..-1]
+        @ssl_context.extra_chain_cert = certs[1..]
         @ssl_context.key = OpenSSL::PKey::RSA.new(File.open(@key_path.to_s))
       else
         # if none cert_path was set, create a self signed test certificate

--- a/lib/midi-smtp-server/tls-transport.rb
+++ b/lib/midi-smtp-server/tls-transport.rb
@@ -44,7 +44,7 @@ module MidiSmtpServer
         raise "File \”#{@key_path}\" does not exist or is not a regular file. Could not load private key." unless File.file?(@key_path.to_s)
         # try to load certificate and key
         cert_lines = File.read(@cert_path.to_s).lines
-        cert_indexes = cert_lines.each_with_index.map { |line, index| index if line.include?('BEGIN CERT') }.compact
+        cert_indexes = cert_lines.each_with_index.map { |line, index| index if line.downcase.include?('begin cert') }.compact
         certs = []
         cert_indexes.each_with_index do |cert_index, current_index|
           end_index = (cert_indexes[current_index + 1] || 0) - 1

--- a/lib/midi-smtp-server/tls-transport.rb
+++ b/lib/midi-smtp-server/tls-transport.rb
@@ -47,11 +47,11 @@ module MidiSmtpServer
         cert_indexes = cert_lines.each_with_index.map { |line, index| index if line.downcase.include?('begin cert') }.compact
         certs = []
         cert_indexes.each_with_index do |cert_index, current_index|
-          end_index = (cert_indexes[current_index + 1] || 0) - 1
+          end_index = current_index + 1 < cert_indexes.length ? cert_indexes[current_index + 1] : -1
           certs << OpenSSL::X509::Certificate.new(cert_lines[cert_index..end_index].join)
         end
-        @ssl_context.cert = certs[0]
-        @ssl_context.extra_chain_cert = certs[1..]
+        @ssl_context.cert = certs.first
+        @ssl_context.chain = certs
         @ssl_context.key = OpenSSL::PKey::RSA.new(File.open(@key_path.to_s))
       else
         # if none cert_path was set, create a self signed test certificate

--- a/lib/midi-smtp-server/tls-transport.rb
+++ b/lib/midi-smtp-server/tls-transport.rb
@@ -43,7 +43,15 @@ module MidiSmtpServer
         raise "File \”#{@cert_path}\" does not exist or is not a regular file. Could not load certificate." unless File.file?(@cert_path.to_s)
         raise "File \”#{@key_path}\" does not exist or is not a regular file. Could not load private key." unless File.file?(@key_path.to_s)
         # try to load certificate and key
-        @ssl_context.cert = OpenSSL::X509::Certificate.new(File.open(@cert_path.to_s))
+        cert_lines = File.read(@cert_path.to_s).lines
+        cert_indexes = cert_lines.each_with_index.map{|line, index| index if line.match?(/BEGIN CERT/)}.compact
+        certs = []
+        cert_indexes.each_with_index do |cert_index, current_index|
+          end_index = (cert_indexes[current_index + 1] || 0) - 1
+          certs << OpenSSL::X509::Certificate.new(cert_lines[cert_index..end_index].join)
+        end
+        @ssl_context.cert = certs[0]
+        @ssl_context.extra_chain_cert = certs[1..-1]
         @ssl_context.key = OpenSSL::PKey::RSA.new(File.open(@key_path.to_s))
       else
         # if none cert_path was set, create a self signed test certificate

--- a/lib/midi-smtp-server/tls-transport.rb
+++ b/lib/midi-smtp-server/tls-transport.rb
@@ -51,7 +51,7 @@ module MidiSmtpServer
           certs << OpenSSL::X509::Certificate.new(cert_lines[cert_index..end_index].join)
         end
         @ssl_context.cert = certs.first
-        @ssl_context.chain = certs
+        @ssl_context.extra_chain_cert = certs
         @ssl_context.key = OpenSSL::PKey::RSA.new(File.open(@key_path.to_s))
       else
         # if none cert_path was set, create a self signed test certificate


### PR DESCRIPTION
**Describe the changes**
Right now TLS does not support certs that have full chain included in them. This PR adds support for cert files that have cert chain in it. Some clients (such as ruby) will raise `certificate verify failed` error if server does not provide full chain. I experienced this with certs generated by Lets Encrypt.

**Test case**
Steps to check the changes:
1. User a cert file that has full chain of certs in it
2. Try to connect with ruby net/smtp with `OpenSSL::SSL::VERIFY_PEER` mode
3. Observe `certificate verify failed` error

**Expected behavior**
Ruby smtp client should not raise error when using valid cert (e.g. Lets Encrypt)

**System tested on (please complete the following information):**
 - OS: OSX 11
 - Ruby: 3.0

**Additional information**
I still need tests for this PR. Can you please provide some guidance what would be a good test setup for this? Is it enough if I just check that `extra_chain_cert` is set on `@ssl_context`?