### PR TITLE
Sleep less on IO::WaitReadable for faster processing

### DIFF
--- a/.github/workflows/push-and-pr-testing-ruby-ci.yml
+++ b/.github/workflows/push-and-pr-testing-ruby-ci.yml
@@ -41,7 +41,7 @@ jobs:
         # handle IPv6 issues with bundler
         echo ":ipv4_fallback_enabled: true" > .gemrc
         export GEMRC=".gemrc"
-        bundle install
+        bundle install --jobs 16
     - name: Run rubocop
       run: |
         bundle exec rake rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -79,3 +79,7 @@ Minitest/MultipleAssertions:
 
 Minitest/TestMethodName:
   Enabled: no
+
+Minitest/TestFileName:
+  Exclude:
+    - "test/construct/*.rb"

--- a/lib/midi-smtp-server.rb
+++ b/lib/midi-smtp-server.rb
@@ -751,7 +751,7 @@ module MidiSmtpServer
             # ignore exception when no input data is available yet
             rescue IO::WaitReadable
               # but wait a few moment to slow down system utilization
-              sleep 0.001
+              sleep 0.01
             end
 
             # check if io_buffer is filled and contains already a line-feed

--- a/lib/midi-smtp-server.rb
+++ b/lib/midi-smtp-server.rb
@@ -751,7 +751,7 @@ module MidiSmtpServer
             # ignore exception when no input data is available yet
             rescue IO::WaitReadable
               # but wait a few moment to slow down system utilization
-              sleep 0.1
+              sleep 0.001
             end
 
             # check if io_buffer is filled and contains already a line-feed

--- a/lib/midi-smtp-server/tls-transport.rb
+++ b/lib/midi-smtp-server/tls-transport.rb
@@ -70,8 +70,8 @@ module MidiSmtpServer
         logger.debug("SSL: generated test certificate\r\n#{@ssl_context.cert.to_text}")
       else
         # if any is set, test the paths
-        raise "File \”#{@cert_path}\" does not exist or is not a regular file. Could not load certificate." unless File.file?(@cert_path.to_s)
-        raise "File \”#{@key_path}\" does not exist or is not a regular file. Could not load private key." unless @key_path.nil? || File.file?(@key_path.to_s)
+        raise "File ”#{@cert_path}\" does not exist or is not a regular file. Could not load certificate." unless File.file?(@cert_path.to_s)
+        raise "File ”#{@key_path}\" does not exist or is not a regular file. Could not load private key." unless @key_path.nil? || File.file?(@key_path.to_s)
         # try to load certificate and key
         cert_lines = File.read(@cert_path.to_s).lines
         # check if the cert file contains a chain of certs

--- a/test/construct/certificate_integration_test_class.rb
+++ b/test/construct/certificate_integration_test_class.rb
@@ -31,6 +31,7 @@ class CertificateIntegrationTest < BaseIntegrationTest
 
   def helper_net_smtp_auth_login_and_simple_send_1_mail_with_ssl
     net_smtp_send_mail @envelope_mail_from, @envelope_rcpt_to, @doc_simple_mail, authentication_id: 'administrator', password: 'password', auth_type: :login, tls_enabled: true
+
     assert_equal @doc_simple_mail, @smtpd.ev_message_data
     assert_equal 'supervisor', @smtpd.ev_auth_authorization_id
   end

--- a/test/integration/memory_only_certificate_test.rb
+++ b/test/integration/memory_only_certificate_test.rb
@@ -26,6 +26,7 @@ class MemoryOnlyCertificateIntegrationTest < BaseIntegrationTest
 
   def test_net_smtp_auth_login_and_simple_send_1_mail_with_ssl
     net_smtp_send_mail @envelope_mail_from, @envelope_rcpt_to, @doc_simple_mail, authentication_id: 'administrator', password: 'password', auth_type: :login, tls_enabled: true
+
     assert_equal @doc_simple_mail, @smtpd.ev_message_data
     assert_equal 'supervisor', @smtpd.ev_auth_authorization_id
   end

--- a/test/integration/ports_and_connections_test.rb
+++ b/test/integration/ports_and_connections_test.rb
@@ -33,6 +33,7 @@ class PortsAndConnectionsIntegrationTest < Minitest::Test
     # test open 1 socket and read welcome message
     channel1 = create_socket
     result1 = get_blocked_socket(channel1)
+
     assert_equal MSG_WELCOME, result1
     close_socket(channel1)
   end
@@ -44,10 +45,12 @@ class PortsAndConnectionsIntegrationTest < Minitest::Test
     channel1 = create_socket
     channel2 = create_socket
     result1 = get_blocked_socket(channel1)
+
     assert_equal MSG_WELCOME, result1
     assert_raises(IO::WaitReadable) { get_nonblocked_socket(channel2) }
     close_socket(channel1)
     result2 = get_blocked_socket(channel2)
+
     assert_equal MSG_WELCOME, result2
     close_socket(channel2)
   end
@@ -61,17 +64,21 @@ class PortsAndConnectionsIntegrationTest < Minitest::Test
     channel2 = create_socket
     channel3 = create_socket
     result1 = get_blocked_socket(channel1)
+
     assert_equal MSG_WELCOME, result1
     assert_raises(IO::WaitReadable) { get_nonblocked_socket(channel2) }
     close_socket(channel1)
     result2 = get_blocked_socket(channel2)
+
     assert_equal MSG_WELCOME, result2
     close_socket(channel2)
     result3 = get_blocked_socket(channel3)
+
     assert_equal MSG_ABORT, result3
     assert_raises(Errno::EPIPE) { 100.times { send_blocked_socket(channel3, "NOOP\r\n") } }
     result3 = +''
     100.times { result3 << get_state_ignored_socket(channel3, 1000, 0.1) }
+
     assert_empty result3
     close_socket(channel3)
   end

--- a/test/integration/send_mails_test.rb
+++ b/test/integration/send_mails_test.rb
@@ -28,6 +28,7 @@ class SendMailsIntegrationTest < BaseIntegrationTest
 
   def test_net_smtp_simple_send_1_mail
     net_smtp_send_mail @envelope_mail_from, @envelope_rcpt_to, @doc_simple_mail
+
     assert_equal @doc_simple_mail, @smtpd.ev_message_data
   end
 
@@ -35,17 +36,20 @@ class SendMailsIntegrationTest < BaseIntegrationTest
     10.times do
       net_smtp_send_mail @envelope_mail_from, @envelope_rcpt_to, @doc_simple_mail
     end
+
     assert_equal @doc_simple_mail, @smtpd.ev_message_data
   end
 
   def test_net_smtp_auth_plain_and_simple_send_1_mail
     net_smtp_send_mail @envelope_mail_from, @envelope_rcpt_to, @doc_simple_mail, authentication_id: 'administrator', password: 'password', auth_type: :plain
+
     assert_equal @doc_simple_mail, @smtpd.ev_message_data
     assert_equal 'supervisor', @smtpd.ev_auth_authorization_id
   end
 
   def test_net_smtp_auth_login_and_simple_send_1_mail
     net_smtp_send_mail @envelope_mail_from, @envelope_rcpt_to, @doc_simple_mail, authentication_id: 'administrator', password: 'password', auth_type: :login
+
     assert_equal @doc_simple_mail, @smtpd.ev_message_data
     assert_equal 'supervisor', @smtpd.ev_auth_authorization_id
   end
@@ -56,11 +60,13 @@ class SendMailsIntegrationTest < BaseIntegrationTest
 
   def test_mikel_mail_simple_send_1_mail
     mikel_mail_send_mail @envelope_mail_from, @envelope_rcpt_to, @doc_simple_mail
+
     assert_equal @doc_simple_mail, @smtpd.ev_message_data
   end
 
   def test_mikel_mail_simple_send_1_mail_starttls
     mikel_mail_send_mail @envelope_mail_from, @envelope_rcpt_to, @doc_simple_mail, authentication_id: 'administrator', password: 'password', enable_starttls: true
+
     assert_equal @doc_simple_mail, @smtpd.ev_message_data
     assert_equal 'supervisor', @smtpd.ev_auth_authorization_id
   end

--- a/test/specs/defaults_test.rb
+++ b/test/specs/defaults_test.rb
@@ -10,6 +10,7 @@ describe MidiSmtpServerTest do
   describe 'defaults exception on empty hosts' do
     it 'must raise no hosts defined!' do
       err = expect { MidiSmtpServer::Smtpd.new(ports: 2525, hosts: '') }.must_raise RuntimeError
+
       assert_match(/No hosts defined!/, err.message)
     end
   end
@@ -17,6 +18,7 @@ describe MidiSmtpServerTest do
   describe 'defaults exception on empty host in hosts' do
     it 'must raise empty host defined!' do
       err = expect { MidiSmtpServer::Smtpd.new(ports: 2525, hosts: '1.2.3.4,,5.6.7.8') }.must_raise RuntimeError
+
       assert_match(/Detected an empty identifier in given hosts!/, err.message)
     end
   end

--- a/test/unit/process_line_random_test.rb
+++ b/test/unit/process_line_random_test.rb
@@ -26,6 +26,7 @@ class ProcessLineRandomUnitTest < Minitest::Test
     setup_session
     helo_str = 'Process line unit test'
     result = @smtpd.process_line(@session, "HELO #{helo_str}", "\r\n")
+
     assert_equal "250 OK #{@session[:ctx][:server][:helo_response]}", result
     assert_equal @session[:ctx][:server][:helo], helo_str
   end
@@ -34,6 +35,7 @@ class ProcessLineRandomUnitTest < Minitest::Test
     setup_session
     helo_str = '  Process line unit test   '
     result = @smtpd.process_line(@session, "hElO #{helo_str}", "\r\n")
+
     assert_equal "250 OK #{@session[:ctx][:server][:helo_response]}", result
     assert_equal @session[:ctx][:server][:helo], helo_str.strip
   end
@@ -42,6 +44,7 @@ class ProcessLineRandomUnitTest < Minitest::Test
     setup_session
     helo_str = '  Process line unit test   '
     result = @smtpd.process_line(@session, "eHlO #{helo_str}", "\r\n")
+
     assert_equal "250-#{@session[:ctx][:server][:helo_response]}\r\n250-8BITMIME\r\n250-SMTPUTF8\r\n250-PIPELINING\r\n250-AUTH LOGIN PLAIN\r\n250 OK", result
     assert_equal @session[:ctx][:server][:helo], helo_str.strip
   end

--- a/test/unit/process_line_test.rb
+++ b/test/unit/process_line_test.rb
@@ -79,6 +79,7 @@ class ProcessLineUnitTest < Minitest::Test
   def test_00_ehlo
     helo_str = 'Process line unit test'
     result = @smtpd.process_line(@session, "EHLO #{helo_str}", "\r\n")
+
     assert_equal "250-#{@session[:ctx][:server][:helo_response]}\r\n250-8BITMIME\r\n250-SMTPUTF8\r\n250-AUTH LOGIN PLAIN\r\n250-STARTTLS\r\n250 OK", result
     assert_equal @session[:ctx][:server][:helo], helo_str
   end
@@ -90,8 +91,10 @@ class ProcessLineUnitTest < Minitest::Test
 
   def test_10_auth_login_simulate_fail
     result = @smtpd.process_line(@session, 'AUTH LOGIN', "\r\n")
+
     assert_equal (+'') << '334 ' << Base64.strict_encode64('Username:'), result
     result = @smtpd.process_line(@session, Base64.strict_encode64('administrator'), "\r\n")
+
     assert_equal (+'') << '334 ' << Base64.strict_encode64('Password:'), result
     assert_raises(MidiSmtpServer::Smtpd535Exception) { @smtpd.process_line(@session, Base64.strict_encode64('error_password'), "\r\n") }
     assert_equal 'administrator', @smtpd.ev_auth_authentication_id
@@ -103,8 +106,10 @@ class ProcessLineUnitTest < Minitest::Test
 
   def test_11_auth_plain_authenticate_supervisor
     result = @smtpd.process_line(@session, 'AUTH PLAIN', "\r\n")
+
     assert_equal '334 ', result
     result = @smtpd.process_line(@session, 'AGFkbWluaXN0cmF0b3IAcGFzc3dvcmQ', "\r\n")
+
     assert_equal '235 OK', result
     assert_equal 'administrator', @smtpd.ev_auth_authentication_id
     assert_equal 'password', @smtpd.ev_auth_authentication
@@ -117,6 +122,7 @@ class ProcessLineUnitTest < Minitest::Test
   def test_20_mail_from
     address_str = 'demo@local.local'
     result = @smtpd.process_line(@session, "MAIL FROM: #{address_str}", "\r\n")
+
     assert_equal '250 OK', result
     assert_equal address_str, @session[:ctx][:envelope][:from]
   end
@@ -125,8 +131,10 @@ class ProcessLineUnitTest < Minitest::Test
     address_str1 = 'demo1@local.local'
     address_str2 = 'demo2@local.local'
     result = @smtpd.process_line(@session, "RCPT TO: #{address_str1}", "\r\n")
+
     assert_equal '250 OK', result
     result = @smtpd.process_line(@session, "RCPT TO: #{address_str2}", "\r\n")
+
     assert_equal '250 OK', result
     assert_equal 2, @session[:ctx][:envelope][:to].length
     assert_equal address_str1, @session[:ctx][:envelope][:to][0]
@@ -135,6 +143,7 @@ class ProcessLineUnitTest < Minitest::Test
 
   def test_40_data
     result = @smtpd.process_line(@session, 'DATA', "\r\n")
+
     assert result.start_with?('354 ')
     @smtpd.process_line(@session, 'From: <demo@local.local>', "\r\n")
     @smtpd.process_line(@session, 'To: <demo1@local.local>, <demo2@local.local>', "\r\n")
@@ -145,6 +154,7 @@ class ProcessLineUnitTest < Minitest::Test
     @smtpd.process_line(@session, 'Have fun.', "\r\n")
     @smtpd.process_line(@session, +'..', "\r\n")
     result = @smtpd.process_line(@session, '.', "\r\n")
+
     assert result.start_with?('250 ')
     assert_equal :CMD_RSET, @session[:cmd_sequence]
     assert_equal (-1), @session[:ctx][:message][:bytesize]
@@ -153,6 +163,7 @@ class ProcessLineUnitTest < Minitest::Test
     assert_equal 174, @smtpd.ev_message_bytesize
     assert @smtpd.ev_message_data.start_with?("Received: test header\r\n")
     m = Mail.read_from_string(@smtpd.ev_message_data)
+
     assert_equal 'demo@local.local', m.from[0]
     assert_equal 'Unit Test', m.subject
     assert_equal 'test header', m.header['Received'].value
@@ -162,17 +173,20 @@ class ProcessLineUnitTest < Minitest::Test
 
   def test_90_noop
     result = @smtpd.process_line(@session, 'NOOP', "\r\n")
+
     assert_equal '250 OK', result
   end
 
   def test_91_rset
     result = @smtpd.process_line(@session, 'RSET', "\r\n")
+
     assert_equal '250 OK', result
     assert_equal :CMD_RSET, @session[:cmd_sequence]
   end
 
   def test_99_quit
     result = @smtpd.process_line(@session, 'QUIT', "\r\n")
+
     assert_equal '', result
     assert_equal :CMD_QUIT, @session[:cmd_sequence]
   end

--- a/test/unit/process_reset_session_test.rb
+++ b/test/unit/process_reset_session_test.rb
@@ -11,16 +11,19 @@ class ProcessResetSessionUnitTest < Minitest::Test
 
   def test_reset_helo
     @smtpd.process_reset_session(@session, connection_initialize: true)
+
     assert_equal :CMD_HELO, @session[:cmd_sequence]
   end
 
   def test_reset_rset
     @smtpd.process_reset_session(@session, connection_initialize: false)
+
     assert_equal :CMD_RSET, @session[:cmd_sequence]
   end
 
   def test_session_status
     @smtpd.process_reset_session(@session, connection_initialize: true)
+
     assert_instance_of Hash, @session[:auth_challenge]
     assert_equal '', @session[:ctx][:server][:local_host]
     assert_equal '', @session[:ctx][:server][:local_ip]


### PR DESCRIPTION
**Describe the changes**

Reduces sleeping from 0.1 to 0.01 seconds when waiting on input data from a socket. 

Testing locally it takes 0.2 seconds to send a sample email vs the 1.1 seconds it used to. My understanding is sleep is added on `IO::WaitReadable` exception in order to not waste CPU cycles. I tested an empty loop `loop { sleep 0.001 }` and it was taking 1.6% of CPU time. I think the trade-off is acceptable here - email can be processed 5x faster for modest CPU waste (especially CPU waste is there only when raising `IO::WaitReadable` error).

**System tested on (please complete the following information):**
 - OS: macOS 13.1 
 - Ruby: 3.2.0

**Additional information**
Add any other information about the changes here.
