### PR TITLE
Add support for setting process name

### DIFF
--- a/.github/workflows/push-and-pr-testing-ruby-ci.yml
+++ b/.github/workflows/push-and-pr-testing-ruby-ci.yml
@@ -40,7 +40,7 @@ jobs:
         # handle IPv6 issues with bundler
         echo ":ipv4_fallback_enabled: true" > .gemrc
         export GEMRC=".gemrc"
-        bundle install
+        bundle install -j8
     - name: Run rubocop
       run: |
         bundle exec rake rubocop

--- a/.github/workflows/push-and-pr-testing-ruby-ci.yml
+++ b/.github/workflows/push-and-pr-testing-ruby-ci.yml
@@ -40,7 +40,7 @@ jobs:
         # handle IPv6 issues with bundler
         echo ":ipv4_fallback_enabled: true" > .gemrc
         export GEMRC=".gemrc"
-        bundle install -j16
+        bundle install
     - name: Run rubocop
       run: |
         bundle exec rake rubocop

--- a/.github/workflows/push-and-pr-testing-ruby-ci.yml
+++ b/.github/workflows/push-and-pr-testing-ruby-ci.yml
@@ -40,7 +40,7 @@ jobs:
         # handle IPv6 issues with bundler
         echo ":ipv4_fallback_enabled: true" > .gemrc
         export GEMRC=".gemrc"
-        bundle install -j8
+        bundle install -j16
     - name: Run rubocop
       run: |
         bundle exec rake rubocop

--- a/lib/midi-smtp-server.rb
+++ b/lib/midi-smtp-server.rb
@@ -143,15 +143,21 @@ module MidiSmtpServer
     # before joining the server threads, check and wait optionally a few seconds
     # to let the service(s) come up
     def join(sleep_seconds_before_join: 1)
+      # set process name
+      $0 = "[MidiSmtp] #{ARGV.join(' ')} (main)"
       # check already existing TCPServers
       return if @tcp_servers.empty?
       # check number of processes to pre-fork
 
       if pre_fork?
         # create a number of pre-fork processes and attach and join threads within workers
+        idx = 0
         @pre_fork.times do
           # append worker pid to list of workers
           @workers << fork do
+            # set forked process name
+            $0 = "[MidiSmtp] #{ARGV.join(' ')} (worker #{idx})"
+            idx += 1
             # set state for a forked process
             @is_forked = true
             # just attach and join the threads to forked worker process

--- a/test/integration/io_waitreadable_test.rb
+++ b/test/integration/io_waitreadable_test.rb
@@ -50,7 +50,7 @@ class IoWaitReadableIntegrationSlowTest < IoWaitReadableIntegrationTest
   def test_slow_io_waitreadable_sleep
     # This test hits IO::WaitReadable exception multiple times
     # For that, this test must run longer than 1 second
-    assert measure_io_waitreadable_sleep > 1
+    assert_operator measure_io_waitreadable_sleep, :>, 1
   end
 
 end
@@ -67,7 +67,7 @@ class IoWaitReadableIntegrationFastTest < IoWaitReadableIntegrationTest
   def test_fast_io_waitreadable_sleep
     # This test hits IO::WaitReadable exception multiple times
     # For that, this test must run longer than 1 second
-    assert measure_io_waitreadable_sleep < 1
+    assert_operator measure_io_waitreadable_sleep, :<, 1
   end
 
 end


### PR DESCRIPTION
**Describe the changes**
Updates process name for main thread with `[MidiSmtp] #{ARGV.join(' ')} (main)` and for forked threads with `[MidiSmtp] #{ARGV.join(' ')} (worker #{idx})`

**Test case**
Steps to check the changes:
1. Run server without forking
2. Check process name (`ps aux | grep Midi`) is `[MidiSmtp] .... (main)`
3. Run server with forking
4. Check process names for main and worker threads

**Expected behavior**
Thread names should start with `[MidiSmtp]`

**System tested on (please complete the following information):**
 - OS: OSX 14.1
 - Ruby: 3.2.2
